### PR TITLE
`sudo` keyword is deprecated

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,6 @@ os: linux
 
 dist: xenial
 
-# Prefer docker containers
-sudo: required
-
 language: python
 
 python:


### PR DESCRIPTION
See https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration