### PR TITLE
use callable instead of hasattr(obj, '__call__')

### DIFF
--- a/Cheetah/NameMapper.py
+++ b/Cheetah/NameMapper.py
@@ -228,7 +228,7 @@ def _valueForName(obj, name, executeCallables=False):
             except AttributeError:
                 _raiseNotFoundException(key, obj)
 
-        if executeCallables and hasattr(nextObj, '__call__') and \
+        if executeCallables and callable(nextObj) and \
                 not _isInstanceOrClass(nextObj):
             obj = nextObj()
         else:

--- a/Cheetah/Parser.py
+++ b/Cheetah/Parser.py
@@ -1427,7 +1427,7 @@ class _HighLevelParser(_LowLevelParser):
                 handler = getattr(self, val)
             elif isinstance(val, type):
                 handler = val(self)
-            elif hasattr(val, '__call__'):
+            elif callable(val):
                 handler = val
             elif val is None:
                 handler = val

--- a/Cheetah/Template.py
+++ b/Cheetah/Template.py
@@ -904,7 +904,7 @@ class Template(Servlet):
         """
         if hasattr(arg, 'preprocess'):
             return arg
-        elif hasattr(arg, '__call__'):
+        elif callable(arg):
             class WrapperPreprocessor:
                 def preprocess(self, source, file):
                     return arg(source, file)


### PR DESCRIPTION
callable() is more accurate because an object may be callable if it has a '__call__' method defined, or if it has the lower level tp_call struct available. See PyCallable_Check at http://svn.python.org/projects/python/trunk/Objects/object.c