### PR TITLE
Fix use of uninitialized variable in _namemapper.c

### DIFF
--- a/Cheetah/Tests/SyntaxAndOutput.py
+++ b/Cheetah/Tests/SyntaxAndOutput.py
@@ -3049,6 +3049,12 @@ class GetVar(OutputTest):               # Template.getVar()
         self.verify("$getVar('$bogus',  1234)",
                     "1234")
 
+    def test6(self):
+        """$getVar('$') raises ValueError
+        """
+        with self.assertRaises(ValueError):
+            self.verify("$getVar('$')", "never get here")
+
 
 class MiscComplexSyntax(OutputTest):
     def test1(self):

--- a/Cheetah/c/_namemapper.c
+++ b/Cheetah/c/_namemapper.c
@@ -268,11 +268,16 @@ static PyObject *namemapper_valueForName(PYARGS)
 
     createNameCopyAndChunks();
 
-    theValue = PyNamemapper_valueForName(obj, nameChunks, numChunks, executeCallables);
-    free(nameCopy);
-    if (wrapInternalNotFoundException(name, obj)) {
+    if (numChunks <= 0) {
+        PyErr_SetString(PyExc_ValueError, "Invalid lookup of empty name");
         theValue = NULL;
+    } else {
+        theValue = PyNamemapper_valueForName(obj, nameChunks, numChunks, executeCallables);
+        if (wrapInternalNotFoundException(name, obj)) {
+            theValue = NULL;
+        }
     }
+    free(nameCopy);
     return theValue;
 }
 
@@ -299,6 +304,11 @@ static PyObject *namemapper_valueFromSearchList(PYARGS)
     }
 
     createNameCopyAndChunks();
+
+    if (numChunks <= 0) {
+        PyErr_SetString(PyExc_ValueError, "Invalid lookup of empty name");
+        goto done;
+    }
 
     iterator = PyObject_GetIter(searchList);
     if (iterator == NULL) {
@@ -354,6 +364,11 @@ static PyObject *namemapper_valueFromFrameOrSearchList(PyObject *self, PyObject 
     }
 
     createNameCopyAndChunks();
+
+    if (numChunks <= 0) {
+        PyErr_SetString(PyExc_ValueError, "Invalid lookup of empty name");
+        goto done;
+    }
 
     nameSpace = PyEval_GetLocals();
     checkForNameInNameSpaceAndReturnIfFound(FALSE);
@@ -417,6 +432,11 @@ static PyObject *namemapper_valueFromFrame(PyObject *self, PyObject *args, PyObj
     }
 
     createNameCopyAndChunks();
+
+    if (numChunks <= 0) {
+        PyErr_SetString(PyExc_ValueError, "Invalid lookup of empty name");
+        goto done;
+    }
 
     nameSpace = PyEval_GetLocals();
     checkForNameInNameSpaceAndReturnIfFound(FALSE);

--- a/Cheetah/c/_namemapper.c
+++ b/Cheetah/c/_namemapper.c
@@ -117,18 +117,18 @@ static int getNameChunks(char *nameChunks[], char *name, char *nameCopy)
 
     currChunk = nameCopy;
     while ('\0' != (c = *nameCopy)){
-    if ('.' == c) {
-        if (currChunkNum >= (MAXCHUNKS-2)) { /* avoid overflowing nameChunks[] */
-            PyErr_SetString(TooManyPeriods, name);
-            return 0;
-        }
+        if ('.' == c) {
+            if (currChunkNum >= (MAXCHUNKS-2)) { /* avoid overflowing nameChunks[] */
+                PyErr_SetString(TooManyPeriods, name);
+                return 0;
+            }
 
-        *nameCopy ='\0';
-        nameChunks[currChunkNum++] = currChunk;
-        nameCopy++;
-        currChunk = nameCopy;
-    } else
-        nameCopy++;
+            *nameCopy ='\0';
+            nameChunks[currChunkNum++] = currChunk;
+            nameCopy++;
+            currChunk = nameCopy;
+        } else
+            nameCopy++;
     }
     if (nameCopy > currChunk) {
         nameChunks[currChunkNum++] = currChunk;

--- a/Cheetah/c/_namemapper.h
+++ b/Cheetah/c/_namemapper.h
@@ -55,7 +55,7 @@
     tmpPntr1 = name; \
     tmpPntr2 = nameCopy;\
     while ((*tmpPntr2++ = *tmpPntr1++)); \
-        numChunks = getNameChunks(nameChunks, name, nameCopy); \
+    numChunks = getNameChunks(nameChunks, name, nameCopy); \
     if (PyErr_Occurred()) {     /* there might have been TooManyPeriods */\
         free(nameCopy);\
         return NULL;\


### PR DESCRIPTION
**Note:** This bug may have security implications for Cheetah users, I'm not sure.  It is present in latest Cheetah release as well as at least as far back as Cheetah 3.1.0.

Three users of `checkForNameInNameSpaceAndReturnIfFound` in _namemapper.c were not checking to see that `numChunks > 0`, and so were using `nameChunks[0]`, which is uninitialized if the name passed in is the empty string.  A fourth function, `namemapper_valueForName`, was probably fine (it didn't use `checkForNameInNameSpaceAndReturnIfFound`), but I fixed it to also raise `ValueError` when asked to look up an empty name, for the sake of consistency.

@JonathanRRogers hunted down this bug in the first place, and he wrote the original test for this, so at least half the credit goes to him.  Thanks Jonathan!  (Errors in this PR, on the other hand, are solely my responsibility.)

Tests are running clean for me on macOS using CPython 2.7, 3.7, and 3.8.  Note, however, that we've found that this bug is easier to reproduce on Linux than on macOS; at least, on Linux you tend to get a SIGSEGV.  I have yet to get one of these on macOS, usually I just get a `NotFound` exception with a garbage string arg.

Fixes #26