### PR TITLE
tox.ini: support Python 3.9

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -5,7 +5,7 @@
 
 [tox]
 minversion = 2.0
-envlist = py27,py3{4,5,6,7,8},py{27,38}-flake8,pypy
+envlist = py27,py3{4,5,6,7,8,9},py{27,38,39}-flake8,pypy
 
 [testenv]
 basepython =
@@ -15,6 +15,7 @@ basepython =
     py36: {env:TOXPYTHON:python3.6}
     py37: {env:TOXPYTHON:python3.7}
     py38: {env:TOXPYTHON:python3.8}
+    py39: {env:TOXPYTHON:python3.9}
     pypy: {env:TOXPYTHON:pypy}
 commands =
     {envpython} --version
@@ -63,6 +64,10 @@ commands =
 commands =
     {[tests]commands}
 
+[testenv:py39]
+commands =
+    {[tests]commands}
+
 [testenv:py27-flake8]
 deps =
     flake8
@@ -71,6 +76,13 @@ commands =
     flake8 .
 
 [testenv:py38-flake8]
+deps =
+    flake8
+commands =
+    {[testenv]commands}
+    flake8 .
+
+[testenv:py39-flake8]
 deps =
     flake8
 commands =


### PR DESCRIPTION
Targets are added to support testing with Python 3.9; the py39 and py39-flake8 targets both run successfully.