### PR TITLE
Skip test_import_bootlocale() on Python 3.10

### DIFF
--- a/Cheetah/Tests/ImportHooks.py
+++ b/Cheetah/Tests/ImportHooks.py
@@ -87,7 +87,9 @@ class ImportHooksTest(unittest.TestCase):
                 return
         raise self.fail("All builtin modules are imported")
 
-    if not PY2:
+    # _bootlocale was removed in Python 3.10:
+    # https://bugs.python.org/issue42208
+    if not PY2 and sys.version_info < (3, 10):
         def test_import_bootlocale(self):
             if '_bootlocale' in sys.modules:
                 del sys.modules['_bootlocale']


### PR DESCRIPTION
The _bootlocale module has been removed from Python 3.10:
https://github.com/python/cpython/commit/b62bdf71ea0cd52041d49691d8ae3dc645bd48e1
https://bugs.python.org/issue42208