### PR TITLE
Add the ability to load searchlist variables from a JSON file via the CLI

### DIFF
--- a/Cheetah/CheetahWrapper.py
+++ b/Cheetah/CheetahWrapper.py
@@ -254,10 +254,10 @@ Files are %s""", args, pprint.pformat(vars(opts)), files)
             f.close()
             self.searchList.insert(0, unpickled)
         if opts.json:
-            f = open(opts.json,'r')
+            f = open(opts.json, 'r')
             unjsoned = json.load(f)
             f.close()
-            self.searchList.insert(0,unjsoned)
+            self.searchList.insert(0, unjsoned)
 
     ##################################################
     # COMMAND METHODS

--- a/Cheetah/CheetahWrapper.py
+++ b/Cheetah/CheetahWrapper.py
@@ -7,6 +7,7 @@ import pprint
 import re
 import shutil
 import sys
+import json
 try:
     import cPickle as pickle
 except ImportError:  # PY3
@@ -177,6 +178,8 @@ class CheetahWrapper(object):
             help='Pass the environment into the search list')
         pao("--pickle", action="store", dest="pickle", default="",
             help='Unpickle FILE and pass it through in the search list')
+        pao("--json", action="store", dest="json", default="",
+            help='Read from JSON FILE and pass it through in the search list')
         pao("--flat", action="store_true", dest="flat", default=False,
             help='Do not build destination subdirectories')
         pao("--nobackup", action="store_true", dest="nobackup", default=False,
@@ -250,6 +253,11 @@ Files are %s""", args, pprint.pformat(vars(opts)), files)
             unpickled = pickle.load(f)
             f.close()
             self.searchList.insert(0, unpickled)
+        if opts.json:
+            f = open(opts.json, 'r')
+            unjsoned = json.load(f)
+            f.close()
+            self.searchList.insert(0, unjsoned)
 
     ##################################################
     # COMMAND METHODS

--- a/Cheetah/CheetahWrapper.py
+++ b/Cheetah/CheetahWrapper.py
@@ -7,6 +7,7 @@ import pprint
 import re
 import shutil
 import sys
+import json
 try:
     import cPickle as pickle
 except ImportError:  # PY3
@@ -177,6 +178,8 @@ class CheetahWrapper(object):
             help='Pass the environment into the search list')
         pao("--pickle", action="store", dest="pickle", default="",
             help='Unpickle FILE and pass it through in the search list')
+        pao("--json", action="store", dest="json", default="",
+            help='Read from JSON FILE and pass it through in the search list')
         pao("--flat", action="store_true", dest="flat", default=False,
             help='Do not build destination subdirectories')
         pao("--nobackup", action="store_true", dest="nobackup", default=False,
@@ -250,6 +253,11 @@ Files are %s""", args, pprint.pformat(vars(opts)), files)
             unpickled = pickle.load(f)
             f.close()
             self.searchList.insert(0, unpickled)
+        if opts.json:
+            f = open(opts.json,'r')
+            unjsoned = json.load(f)
+			f.close()
+            self.searchList.insert(0,unjsoned)
 
     ##################################################
     # COMMAND METHODS

--- a/Cheetah/CheetahWrapper.py
+++ b/Cheetah/CheetahWrapper.py
@@ -256,7 +256,7 @@ Files are %s""", args, pprint.pformat(vars(opts)), files)
         if opts.json:
             f = open(opts.json,'r')
             unjsoned = json.load(f)
-			f.close()
+            f.close()
             self.searchList.insert(0,unjsoned)
 
     ##################################################

--- a/Cheetah/TemplateCmdLineIface.py
+++ b/Cheetah/TemplateCmdLineIface.py
@@ -7,6 +7,7 @@ try:
     from cPickle import load
 except ImportError:
     from pickle import load
+from json import load as jsonload
 
 from Cheetah.Version import Version
 
@@ -35,7 +36,7 @@ class CmdLineIface:
     def _processCmdLineArgs(self):
         try:
             self._opts, self._args = getopt.getopt(
-                self._cmdLineArgs, 'h', ['help', 'env', 'pickle=']
+                self._cmdLineArgs, 'h', ['help', 'env', 'pickle=', 'json=']
             )
 
         except getopt.GetoptError as v:
@@ -63,6 +64,19 @@ class CmdLineIface:
                     unpickled = load(f)
                     f.close()
                     self._template.searchList().insert(0, unpickled)
+            if o == '--json':
+                if a == '-':
+                    if hasattr(sys.stdin, 'buffer'):
+                        stdin = sys.stdin.buffer  # Read binary data from stdin
+                    else:
+                        stdin = sys.stdin
+                    unjsoned = jsonload(stdin)
+                    self._template.searchList().insert(0, unjsoned)
+                else:
+                    f = open(a, 'r')
+                    unjsoned = jsonload(f)
+                    f.close()
+                    self._template.searchList().insert(0, unjsoned)
 
     def usage(self):
         return """Cheetah %(Version)s template module command-line interface

--- a/devscripts/postrelease
+++ b/devscripts/postrelease
@@ -19,4 +19,4 @@ fi &&
 git checkout $tag~ ANNOUNCE.rst &&
 
 `git var GIT_EDITOR` ANNOUNCE.rst docs/news.rst Cheetah/Version.py README.rst setup.cfg SetupConfig.py &&
-exec git commit --message="Prepare for the next release" ANNOUNCE.rst docs/news.rst Cheetah/Version.py README.rst setup.cfg SetupConfig.py
+exec git commit --message="Build: Prepare for the next release" --message="[skip ci]" ANNOUNCE.rst docs/news.rst Cheetah/Version.py README.rst setup.cfg SetupConfig.py


### PR DESCRIPTION
CLI commandline option --json=<file>

My inclination is to use _with open("jsonfile") as f:_ but I thought I'd stick with the existing convention that pickle uses here to explicitly close the file.

