### PR TITLE
Add load from JSON file to searchlist from CLI interfaces, and unit test coverage.

### DIFF
--- a/Cheetah/CheetahWrapper.py
+++ b/Cheetah/CheetahWrapper.py
@@ -7,6 +7,7 @@ import pprint
 import re
 import shutil
 import sys
+import json
 try:
     import cPickle as pickle
 except ImportError:  # PY3
@@ -177,6 +178,8 @@ class CheetahWrapper(object):
             help='Pass the environment into the search list')
         pao("--pickle", action="store", dest="pickle", default="",
             help='Unpickle FILE and pass it through in the search list')
+        pao("--json", action="store", dest="json", default="",
+            help='Read from JSON FILE and pass it through in the search list')
         pao("--flat", action="store_true", dest="flat", default=False,
             help='Do not build destination subdirectories')
         pao("--nobackup", action="store_true", dest="nobackup", default=False,
@@ -250,6 +253,11 @@ Files are %s""", args, pprint.pformat(vars(opts)), files)
             unpickled = pickle.load(f)
             f.close()
             self.searchList.insert(0, unpickled)
+        if opts.json:
+            f = open(opts.json, 'r')
+            unjsoned = json.load(f)
+            f.close()
+            self.searchList.insert(0, unjsoned)
 
     ##################################################
     # COMMAND METHODS

--- a/Cheetah/TemplateCmdLineIface.py
+++ b/Cheetah/TemplateCmdLineIface.py
@@ -7,6 +7,7 @@ try:
     from cPickle import load
 except ImportError:
     from pickle import load
+from json import load as jsonload
 
 from Cheetah.Version import Version
 
@@ -35,7 +36,7 @@ class CmdLineIface:
     def _processCmdLineArgs(self):
         try:
             self._opts, self._args = getopt.getopt(
-                self._cmdLineArgs, 'h', ['help', 'env', 'pickle=']
+                self._cmdLineArgs, 'h', ['help', 'env', 'pickle=', 'json=']
             )
 
         except getopt.GetoptError as v:
@@ -63,6 +64,19 @@ class CmdLineIface:
                     unpickled = load(f)
                     f.close()
                     self._template.searchList().insert(0, unpickled)
+            if o == '--json':
+                if a == '-':
+                    if hasattr(sys.stdin, 'buffer'):
+                        stdin = sys.stdin.buffer  # Read binary data from stdin
+                    else:
+                        stdin = sys.stdin
+                    unjsoned = jsonload(stdin)
+                    self._template.searchList().insert(0, unjsoned)
+                else:
+                    f = open(a, 'r')
+                    unjsoned = jsonload(f)
+                    f.close()
+                    self._template.searchList().insert(0, unjsoned)
 
     def usage(self):
         return """Cheetah %(Version)s template module command-line interface


### PR DESCRIPTION
Using command line flag `--json <filename>` or `--json=<filename>` you can populate your searchlist from a JSON file.

This feature/flag was added to both CheetahWrapper.py (cheetah.exe) and TemplateCmdLineIface.py (invoking a compiled template class directly from the CLI).

Unit tests were added for both CLI functions, and a unit test was also added for the `--pickle` function in CheetahWrapper.py, previously missing.

