### PR TITLE
Use relative imports

### DIFF
--- a/Cheetah/CacheRegion.py
+++ b/Cheetah/CacheRegion.py
@@ -25,7 +25,7 @@ except ImportError:
     from md5 import md5
 
 import time
-import Cheetah.CacheStore
+from . import CacheStore
 
 
 class CacheItem(object):
@@ -105,7 +105,7 @@ class CacheRegion(object):
         self._regionID = regionID
         self._templateCacheIdPrefix = templateCacheIdPrefix
         if not cacheStore:
-            cacheStore = Cheetah.CacheStore.MemoryCacheStore()
+            cacheStore = CacheStore.MemoryCacheStore()
         self._cacheStore = cacheStore
         self._wrappedCacheDataStore = _CacheDataStoreWrapper(
             cacheStore, keyPrefix=templateCacheIdPrefix + ':' + regionID + ':')

--- a/Cheetah/CheetahWrapper.py
+++ b/Cheetah/CheetahWrapper.py
@@ -14,11 +14,11 @@ except ImportError:  # PY3
     import pickle as pickle
 from optparse import OptionParser
 
-from Cheetah.Compiler import DEFAULT_COMPILER_SETTINGS
-from Cheetah.Template import Template
-from Cheetah.Utils.Misc import mkdirsWithPyInitFiles
-from Cheetah.Version import Version
-from Cheetah.compat import PY2
+from .Compiler import DEFAULT_COMPILER_SETTINGS
+from .Template import Template
+from .Utils.Misc import mkdirsWithPyInitFiles
+from .Version import Version
+from .compat import PY2
 
 optionDashesRE = re.compile(R"^-{1,2}")
 moduleNameRE = re.compile(R"^[a-zA-Z_][a-zA-Z_0-9]*$")
@@ -227,7 +227,7 @@ Files are %s""", args, pprint.pformat(vars(opts)), files)
         if opts.print_settings:
             print()
             print('>> Available Cheetah compiler settings:')
-            from Cheetah.Compiler import _DEFAULT_COMPILER_SETTINGS
+            from .Compiler import _DEFAULT_COMPILER_SETTINGS
             listing = _DEFAULT_COMPILER_SETTINGS
             listing.sort(key=lambda _l: _l[0][0].lower())
 
@@ -266,7 +266,7 @@ Files are %s""", args, pprint.pformat(vars(opts)), files)
         self._compileOrFill()
 
     def fill(self):
-        from Cheetah.ImportHooks import install
+        from .ImportHooks import install
         install()
         self._compileOrFill()
 
@@ -291,7 +291,7 @@ you do have write permission to and re-run the tests.""")
             os.remove(TEST_WRITE_FILENAME)
         # @@MO: End ugly kludge.
         import unittest
-        from Cheetah.Tests import Test
+        from .Tests import Test
         verbosity = 1
         if '-q' in self.testOpts:
             verbosity = 0

--- a/Cheetah/Compiler.py
+++ b/Cheetah/Compiler.py
@@ -19,16 +19,16 @@ import warnings
 import copy
 import codecs
 
-from Cheetah.Version import Version, VersionTuple
-from Cheetah.SettingsManager import SettingsManager
-from Cheetah.Utils.Indenter import indentize  # an undocumented preprocessor
-from Cheetah import NameMapper
-from Cheetah.Parser import Parser, ParseError, specialVarRE, \
+from .Version import Version, VersionTuple
+from .SettingsManager import SettingsManager
+from .Utils.Indenter import indentize  # an undocumented preprocessor
+from . import NameMapper
+from .Parser import Parser, ParseError, specialVarRE, \
     STATIC_CACHE, REFRESH_CACHE, SET_GLOBAL, SET_MODULE, \
     unicodeDirectiveRE, encodingDirectiveRE, escapedNewlineRE
-from Cheetah.compat import PY2, string_type, unicode
+from .compat import PY2, string_type, unicode
 
-from Cheetah.NameMapper import valueForName, valueFromSearchList, \
+from .NameMapper import valueForName, valueFromSearchList, \
     valueFromFrameOrSearchList
 VFFSL = valueFromFrameOrSearchList
 VFSL = valueFromSearchList
@@ -1749,6 +1749,11 @@ class ModuleCompiler(SettingsManager, GenUtils):
         self._moduleHeaderLines = []
         self._moduleDocStringLines = []
         self._specialVars = {}
+        # we might have been moved to be a sub-package
+        if "__spec__" in globals():
+            package = __spec__.parent   # noqa: F821 undefined name '__spec__'
+        else:
+            package = __package__
         self._importStatements = [
             "import sys",
             "import os",
@@ -1760,18 +1765,19 @@ class ModuleCompiler(SettingsManager, GenUtils):
             "from os.path import getmtime, exists",
             "import time",
             "import types",
-            "from Cheetah.Version import MinCompatibleVersion as "
-            "RequiredCheetahVersion",
-            "from Cheetah.Version import MinCompatibleVersionTuple "
-            "as RequiredCheetahVersionTuple",
-            "from Cheetah.Template import Template",
-            "from Cheetah.DummyTransaction import *",
-            "from Cheetah.NameMapper import NotFound, "
-            "valueForName, valueFromSearchList, valueFromFrameOrSearchList",
-            "from Cheetah.CacheRegion import CacheRegion",
-            "import Cheetah.Filters as Filters",
-            "import Cheetah.ErrorCatchers as ErrorCatchers",
-            "from Cheetah.compat import unicode",
+            "from %s.Version import MinCompatibleVersion as "
+            "RequiredCheetahVersion" % package,
+            "from %s.Version import MinCompatibleVersionTuple "
+            "as RequiredCheetahVersionTuple" % package,
+            "from %s.Template import Template" % package,
+            "from %s.DummyTransaction import *" % package,
+            "from %s.NameMapper import NotFound, "
+            "valueForName, valueFromSearchList, "
+            "valueFromFrameOrSearchList" % package,
+            "from %s.CacheRegion import CacheRegion" % package,
+            "import %s.Filters as Filters" % package,
+            "import %s.ErrorCatchers as ErrorCatchers" % package,
+            "from %s.compat import unicode" % package,
         ]
 
         self._importedVarNames = ['sys',

--- a/Cheetah/DirectiveAnalyzer.py
+++ b/Cheetah/DirectiveAnalyzer.py
@@ -3,9 +3,9 @@
 import os
 import pprint
 
-from Cheetah import Parser
-from Cheetah import Compiler
-from Cheetah import Template
+from . import Parser
+from . import Compiler
+from . import Template
 
 
 class Analyzer(Parser.Parser):

--- a/Cheetah/Django.py
+++ b/Cheetah/Django.py
@@ -1,4 +1,4 @@
-import Cheetah.Template
+from . import Template
 
 
 def render(template_file, **kwargs):
@@ -13,5 +13,5 @@ def render(template_file, **kwargs):
     import django.http
     import django.template.loader
     source, loader = django.template.loader.find_template_source(template_file)
-    t = Cheetah.Template.Template(source, searchList=[kwargs])
+    t = Template.Template(source, searchList=[kwargs])
     return django.http.HttpResponse(t.__str__())

--- a/Cheetah/DummyTransaction.py
+++ b/Cheetah/DummyTransaction.py
@@ -9,7 +9,7 @@ specific DummyTransaction or DummyResponse behavior
 '''
 
 import logging
-from Cheetah.compat import unicode
+from .compat import unicode
 
 
 class DummyResponseFailure(Exception):

--- a/Cheetah/ErrorCatchers.py
+++ b/Cheetah/ErrorCatchers.py
@@ -1,6 +1,6 @@
 
 import time
-from Cheetah.NameMapper import NotFound
+from .NameMapper import NotFound
 
 
 class Error(Exception):

--- a/Cheetah/FileUtils.py
+++ b/Cheetah/FileUtils.py
@@ -4,7 +4,7 @@ import os
 import os.path
 import re
 from tempfile import NamedTemporaryFile
-from Cheetah.compat import string_type
+from .compat import string_type
 
 
 def _escapeRegexChars(

--- a/Cheetah/Filters.py
+++ b/Cheetah/Filters.py
@@ -6,7 +6,7 @@
     #filter results in output filters Cheetah's $placeholders .
     #transform results in a filter on the entirety of the output
 '''
-from Cheetah.compat import unicode
+from .compat import unicode
 
 # Additional entities WebSafe knows how to transform.  No need to include
 # '<', '>' or '&' since those will have been done already.

--- a/Cheetah/ImportHooks.py
+++ b/Cheetah/ImportHooks.py
@@ -22,10 +22,10 @@ except ImportError:  # PY2
 from threading import RLock
 import traceback
 
-from Cheetah import ImportManager
-from Cheetah.ImportManager import DirOwner
-from Cheetah.Compiler import Compiler
-from Cheetah.convertTmplPathToModuleName import convertTmplPathToModuleName
+from . import ImportManager
+from .ImportManager import DirOwner
+from .Compiler import Compiler
+from .convertTmplPathToModuleName import convertTmplPathToModuleName
 
 _installed = False
 

--- a/Cheetah/ImportManager.py
+++ b/Cheetah/ImportManager.py
@@ -20,7 +20,7 @@ This is a hacked/documented version of Gordon McMillan's iu.py. I have:
 import marshal
 import py_compile
 import sys
-from Cheetah.compat import PY2, string_type, new_module, get_suffixes, \
+from .compat import PY2, string_type, new_module, get_suffixes, \
     load_module_from_file, RecursionError
 if PY2:
     import imp

--- a/Cheetah/LoadTemplate.py
+++ b/Cheetah/LoadTemplate.py
@@ -1,6 +1,6 @@
 import os
 import sys
-from Cheetah.ImportHooks import CheetahDirOwner
+from .ImportHooks import CheetahDirOwner
 
 
 def loadTemplateModule(templatePath, debuglevel=0):

--- a/Cheetah/NameMapper.py
+++ b/Cheetah/NameMapper.py
@@ -143,7 +143,7 @@ been compiled or falls back to the Python version if not.
 import inspect
 from pprint import pformat
 
-from Cheetah.compat import PY2
+from .compat import PY2
 if PY2:
     from collections import Mapping
 else:
@@ -263,7 +263,7 @@ def hasName(obj, name):
 
 
 try:
-    from Cheetah._namemapper import NotFound, valueForKey, valueForName, \
+    from ._namemapper import NotFound, valueForKey, valueForName, \
         valueFromSearchList, valueFromFrameOrSearchList, valueFromFrame
     C_VERSION = True
 except Exception:

--- a/Cheetah/Parser.py
+++ b/Cheetah/Parser.py
@@ -13,10 +13,10 @@ import re
 import types
 import inspect
 
-from Cheetah.SourceReader import SourceReader
-from Cheetah.Unspecified import Unspecified
-from Cheetah.Macros.I18n import I18n
-from Cheetah.compat import PY2, string_type, unicode
+from .SourceReader import SourceReader
+from .Unspecified import Unspecified
+from .Macros.I18n import I18n
+from .compat import PY2, string_type, unicode
 if PY2:
     from tokenize import pseudoprog
 else:
@@ -2390,7 +2390,7 @@ class _HighLevelParser(_LowLevelParser):
              macroSrc,
              '%end def'])
 
-        from Cheetah.Template import Template
+        from .Template import Template
         templateAPIClass = self.setting('templateAPIClassForDefMacro',
                                         default=Template)
         compilerSettings = self.setting('compilerSettingsForDefMacro',

--- a/Cheetah/SettingsManager.py
+++ b/Cheetah/SettingsManager.py
@@ -11,7 +11,7 @@ try:
     from StringIO import StringIO
 except ImportError:
     from io import StringIO
-from Cheetah.compat import PY2
+from .compat import PY2
 
 
 numberRE = re.compile(Number)

--- a/Cheetah/SourceReader.py
+++ b/Cheetah/SourceReader.py
@@ -1,7 +1,7 @@
 """SourceReader class for Cheetah's Parser and CodeGenerator
 """
 import re
-from Cheetah.compat import unicode
+from .compat import unicode
 
 EOLre = re.compile(r'[ \f\t]*(?:\r\n|\r|\n)')
 EOLZre = re.compile(r'(?:\r\n|\r|\n|\Z)')

--- a/Cheetah/Template.py
+++ b/Cheetah/Template.py
@@ -24,24 +24,24 @@ import pprint
 import cgi  # Used by .webInput() if the template is a CGI script.
 import types
 
-from Cheetah import ErrorCatchers              # for placeholder tags
-from Cheetah import Filters                    # the output filters
-from Cheetah.CacheRegion import CacheRegion
-from Cheetah.CacheStore import MemoryCacheStore  # , MemcachedCacheStore
-from Cheetah.Compiler import Compiler
-from Cheetah.NameMapper import NotFound, valueFromSearchList
-from Cheetah.Parser import ParseError, SourceReader
+from . import ErrorCatchers              # for placeholder tags
+from . import Filters                    # the output filters
+from .CacheRegion import CacheRegion
+from .CacheStore import MemoryCacheStore  # , MemcachedCacheStore
+from .Compiler import Compiler
+from .NameMapper import NotFound, valueFromSearchList
+from .Parser import ParseError, SourceReader
 # Base classes for Template
-from Cheetah.Servlet import Servlet
-from Cheetah.Unspecified import Unspecified
-from Cheetah.Utils.Indenter import Indenter      # and for placeholders
-from Cheetah.Utils.WebInputMixin import _Converter, _lookup, \
+from .Servlet import Servlet
+from .Unspecified import Unspecified
+from .Utils.Indenter import Indenter      # and for placeholders
+from .Utils.WebInputMixin import _Converter, _lookup, \
     NonNumericInputError
-from Cheetah.Version import MinCompatibleVersion
-from Cheetah.Version import convertVersionStringToTuple, \
+from .Version import MinCompatibleVersion
+from .Version import convertVersionStringToTuple, \
     MinCompatibleVersionTuple
-from Cheetah.compat import PY2, string_type, unicode
-from Cheetah.convertTmplPathToModuleName import convertTmplPathToModuleName
+from .compat import PY2, string_type, unicode
+from .convertTmplPathToModuleName import convertTmplPathToModuleName
 
 try:
     from threading import Lock
@@ -1514,7 +1514,7 @@ class Template(Servlet):
         Type 'python yourtemplate.py --help to see what it's capabable of.
         """
 
-        from Cheetah.TemplateCmdLineIface import CmdLineIface
+        from .TemplateCmdLineIface import CmdLineIface
         CmdLineIface(templateObj=self).run()
 
     ##################################################

--- a/Cheetah/TemplateCmdLineIface.py
+++ b/Cheetah/TemplateCmdLineIface.py
@@ -9,7 +9,7 @@ except ImportError:
     from pickle import load
 from json import load as jsonload
 
-from Cheetah.Version import Version
+from .Version import Version
 
 
 class Error(Exception):

--- a/Cheetah/Utils/WebInputMixin.py
+++ b/Cheetah/Utils/WebInputMixin.py
@@ -2,7 +2,7 @@
 transaction variables in bulk.  See the docstring of webInput for full details.
 """
 
-from Cheetah.Utils.Misc import useOrRaise
+from .Misc import useOrRaise
 
 
 class NonNumericInputError(ValueError):

--- a/Cheetah/Utils/htmlDecode.py
+++ b/Cheetah/Utils/htmlDecode.py
@@ -4,7 +4,7 @@
 
 """
 
-from Cheetah.Utils.htmlEncode import htmlCodesReversed
+from .htmlEncode import htmlCodesReversed
 
 
 def htmlDecode(s, codes=htmlCodesReversed):

--- a/Cheetah/__init__.py
+++ b/Cheetah/__init__.py
@@ -13,4 +13,4 @@ Documentation
     https://cheetahtemplate.org/
 '''
 
-from Cheetah.Version import *  # noqa
+from .Version import *  # noqa

--- a/Cheetah/convertTmplPathToModuleName.py
+++ b/Cheetah/convertTmplPathToModuleName.py
@@ -1,6 +1,6 @@
 import os.path
 import string
-from Cheetah.compat import unicode
+from .compat import unicode
 
 letters = None
 try:


### PR DESCRIPTION
This makes it possible to embed Cheetah in other packages without risking conflict with other versions.