### PR TITLE
fixed printing to stdout with encoded output for issue #55

### DIFF
--- a/Cheetah/CheetahWrapper.py
+++ b/Cheetah/CheetahWrapper.py
@@ -592,7 +592,7 @@ you do have write permission to and re-run the tests.""")
             pysrc = TemplateClass.compile(file=sys.stdin,
                                           compilerSettings=compilerSettings,
                                           returnAClass=False)
-            output = pysrc
+            output = pysrc if PY2 else pysrc.decode()
         else:
             output = str(TemplateClass(file=sys.stdin,
                                        compilerSettings=compilerSettings))


### PR DESCRIPTION
Fixed ability to generate template directly to stdout with Python3 on linux. Unable to run regession test but validated change manually.