### PR TITLE
Hide DepricationWarning from CGI

### DIFF
--- a/Cheetah/Template.py
+++ b/Cheetah/Template.py
@@ -22,7 +22,10 @@ except ImportError:
 import traceback
 import pprint
 try:
-    import cgi  # Used by .webInput() if the template is a CGI script.
+    import warnings
+    with warnings.catch_warnings():
+        warnings.filterwarnings("ignore", ".*cgi.*", DeprecationWarning)
+        import cgi  # Used by .webInput() if the template is a CGI script.
 except ImportError:  # Python 3.13+
     from urllib.parse import parse_qs
     cgi = None


### PR DESCRIPTION
As we already know, CGI is not supported in Python 3.13+ and this is handled by 'except ImportError'. 

My suggestion is to hide the warning from the user, since everything still works and the user should not have to worry about CGI.