### PR TITLE
Stop using load_module() in compat

### DIFF
--- a/Cheetah/compat.py
+++ b/Cheetah/compat.py
@@ -53,7 +53,9 @@ else:
 
     def load_module_from_file(base_name, module_name, filename):
         specs = importlib.util.spec_from_file_location(module_name, filename)
-        return specs.loader.load_module()
+        module = importlib.util.module_from_spec(specs)
+        specs.loader.exec_module(module)
+        return module
 
     new_module = types.ModuleType
 


### PR DESCRIPTION
load_module() has been deprecated effectively since it was added, replaced by exec_module in Python 3.5, switch to using that, since load_module() was removed in Python 3.15.

Note this effectively removes support for Python 3.4, but I can reenable that if you prefer.