### PR TITLE
Add compiler setting titleCaseClassNames

### DIFF
--- a/Cheetah/Compiler.py
+++ b/Cheetah/Compiler.py
@@ -12,6 +12,7 @@ import sys
 import os
 import os.path
 from os.path import getmtime
+import keyword
 import re
 import time
 import random
@@ -38,6 +39,25 @@ currentTime = time.time
 
 class Error(Exception):
     pass
+
+
+def titleCaseClassName(name):
+    """Convert a module name to a title case class name
+
+    ``my_template`` becomes ``MyTemplate``. A name that is already
+    in title case is returned unchanged. Leading underscores are preserved.
+    A name that would collide with a Python keyword gets a trailing
+    underscore, so that ``none.tmpl`` defines ``None_``.
+    """
+    stripped = name.lstrip('_')
+    leadingUnderscores = name[:len(name) - len(stripped)]
+    className = leadingUnderscores + ''.join(
+        [part[:1].upper() + part[1:] for part in stripped.split('_')])
+    # None, True and False are not keywords under Python 2 but cannot
+    # be class names there either.
+    if keyword.iskeyword(className) or className in ('None', 'True', 'False'):
+        className += '_'
+    return className
 
 
 # Settings format: (key, default, docstring)
@@ -83,6 +103,11 @@ _DEFAULT_COMPILER_SETTINGS = [
     ('setup__str__method', False, ''),
     ('mainMethodName', 'respond', ''),
     ('mainMethodNameForSubclasses', 'writeBody', ''),
+    ('titleCaseClassNames', False,
+     'Convert the class name of a compiled template to title case: '
+     'my_template.tmpl defines the class MyTemplate. Applies to a class '
+     'name passed to the compiler as well as to one taken from the '
+     'module name'),
     ('indentationStep', ' ' * 4, ''),
     ('initialMethIndentLevel', 2, ''),
     ('monitorSrcFile', False, ''),
@@ -1638,10 +1663,17 @@ class ModuleCompiler(SettingsManager, GenUtils):
 
         self._compiled = False
         self._moduleName = moduleName
+        # The main class name has to be fixed before parsing starts, so a
+        # #compiler-settings directive is too late to change it. Freeze the
+        # setting here and use the frozen value for the #extends imports,
+        # too; otherwise a directive would rename the base class but not
+        # the class of the template itself.
+        self._titleCaseClassNames = self.setting('titleCaseClassNames')
         if not mainClassName:
-            self._mainClassName = moduleName
-        else:
-            self._mainClassName = mainClassName
+            mainClassName = moduleName
+        if self._titleCaseClassNames:
+            mainClassName = titleCaseClassName(mainClassName)
+        self._mainClassName = mainClassName
         self._mainMethodNameArg = mainMethodName
         if mainMethodName:
             self.setSetting('mainMethodName', mainMethodName)
@@ -1802,6 +1834,9 @@ class ModuleCompiler(SettingsManager, GenUtils):
             "currentTime=time.time",
         ]
 
+    def mainClassName(self):
+        return self._mainClassName
+
     def compile(self):
         classCompiler = self._spawnClassCompiler(self._mainClassName)
         if self._baseclassName:
@@ -1887,11 +1922,15 @@ class ModuleCompiler(SettingsManager, GenUtils):
                 klass = klass.strip()
                 chunks = klass.split('.')
                 if len(chunks) == 1:
-                    baseclasses.append(klass)
-                    if klass not in self.importedVarNames():
+                    if klass in self.importedVarNames():
+                        baseclasses.append(klass)
+                    else:
                         modName = klass
                         # we assume the class name to be the module name
                         # and that it's not a builtin:
+                        if self._titleCaseClassNames:
+                            klass = titleCaseClassName(klass)
+                        baseclasses.append(klass)
                         importStatement = "from %s import %s" % (
                             modName, klass)
                         self.addImportStatement(importStatement)
@@ -1915,6 +1954,9 @@ class ModuleCompiler(SettingsManager, GenUtils):
                         if finalClassName != chunks[-2]:
                             # we assume the class name to be the module name
                             modName = '.'.join(chunks)
+                        if self._titleCaseClassNames:
+                            finalClassName = titleCaseClassName(
+                                finalClassName)
                         baseclasses.append(finalClassName)
                         importStatement = "from %s import %s" % (
                             modName, finalClassName)

--- a/Cheetah/LoadTemplate.py
+++ b/Cheetah/LoadTemplate.py
@@ -1,5 +1,6 @@
 import os
 import sys
+from .Compiler import titleCaseClassName
 from .ImportHooks import CheetahDirOwner
 from .compat import ModuleNotFoundError
 
@@ -44,4 +45,8 @@ def loadTemplateModule(templatePath, debuglevel=0):
 def loadTemplateClass(templatePath, debuglevel=0):
     """Load template's class by full or relative path"""
     mod = loadTemplateModule(templatePath, debuglevel=debuglevel)
-    return getattr(mod, mod.__name__)
+    try:
+        return getattr(mod, mod.__name__)
+    except AttributeError:
+        # The template may have been compiled with titleCaseClassNames.
+        return getattr(mod, titleCaseClassName(mod.__name__))

--- a/Cheetah/Template.py
+++ b/Cheetah/Template.py
@@ -779,6 +779,11 @@ class Template(Servlet):
             compiler.compile()
             generatedModuleCode = compiler.getModuleCode()
             outputEncoding = compiler.getModuleEncoding()
+            # The compiler may have derived a different class name,
+            # see the titleCaseClassNames setting. A compilerClass of
+            # one's own need not implement the method.
+            if hasattr(compiler, 'mainClassName'):
+                className = compiler.mainClassName()
 
         if not returnAClass:
             # This is a bit of a hackish solution to make sure

--- a/Cheetah/Tests/ClassNames.py
+++ b/Cheetah/Tests/ClassNames.py
@@ -1,0 +1,266 @@
+'''
+Tests for the ``titleCaseClassNames`` compiler setting.
+'''
+
+import os
+import shutil
+import sys
+import tempfile
+import unittest
+
+from Cheetah.Compiler import ModuleCompiler, titleCaseClassName
+from Cheetah.LoadTemplate import loadTemplateClass
+from Cheetah.Template import Template
+
+
+def compileToSource(source, **kw):
+    """Compile a template and return the generated Python source as text"""
+    pysrc = Template.compile(source, returnAClass=False, **kw)
+    if not isinstance(pysrc, str):
+        pysrc = pysrc.decode('utf-8')
+    return pysrc
+
+
+class TitleCaseClassNameTest(unittest.TestCase):
+
+    def test_underscores(self):
+        self.assertEqual(titleCaseClassName('my_template'), 'MyTemplate')
+        self.assertEqual(titleCaseClassName('my__template'), 'MyTemplate')
+        self.assertEqual(titleCaseClassName('my_2nd_template'),
+                         'My2ndTemplate')
+
+    def test_single_word(self):
+        self.assertEqual(titleCaseClassName('template'), 'Template')
+
+    def test_already_title_case(self):
+        self.assertEqual(titleCaseClassName('MyTemplate'), 'MyTemplate')
+        self.assertEqual(titleCaseClassName('HTMLPage'), 'HTMLPage')
+
+    def test_leading_underscores(self):
+        self.assertEqual(titleCaseClassName('_my_template'), '_MyTemplate')
+        self.assertEqual(titleCaseClassName('__my_template'), '__MyTemplate')
+
+    def test_keywords(self):
+        # class None(Template) is a syntax error.
+        self.assertEqual(titleCaseClassName('none'), 'None_')
+        self.assertEqual(titleCaseClassName('true'), 'True_')
+        self.assertEqual(titleCaseClassName('lambda'), 'Lambda')
+
+
+class CompileTest(unittest.TestCase):
+
+    def compile(self, source, moduleName='my_template', **settings):
+        return compileToSource(source, moduleName=moduleName,
+                               compilerSettings=settings)
+
+
+class ClassNameTest(CompileTest):
+
+    def test_off_by_default(self):
+        pysrc = self.compile('Hello')
+        self.assertIn('class my_template(', pysrc)
+
+    def test_title_case(self):
+        pysrc = self.compile('Hello', titleCaseClassNames=True)
+        self.assertIn('class MyTemplate(', pysrc)
+
+    def test_returns_the_compiled_class(self):
+        klass = Template.compile(
+            'Hello', moduleName='my_template',
+            compilerSettings={'titleCaseClassNames': True})
+        self.assertEqual(klass.__name__, 'MyTemplate')
+        self.assertEqual(str(klass()), 'Hello')
+
+    def test_setting_on_a_template_subclass(self):
+        class TitleCased(Template):
+            _CHEETAH_compilerSettings = {'titleCaseClassNames': True}
+
+        klass = TitleCased.compile('Hello', moduleName='my_template')
+        self.assertEqual(klass.__name__, 'MyTemplate')
+        self.assertEqual(str(klass()), 'Hello')
+
+    def test_compiler_settings_directive_does_not_apply(self):
+        # The class name is fixed before parsing starts, so the directive
+        # comes too late. It must not rename half of the module either.
+        pysrc = self.compile("""\
+#compiler-settings
+titleCaseClassNames = True
+#end compiler-settings
+#extends my_base
+#implements respond
+Hello
+""")
+        self.assertIn('from my_base import my_base', pysrc)
+        self.assertIn('class my_template(my_base)', pysrc)
+
+    def test_explicit_class_name(self):
+        pysrc = compileToSource(
+            'Hello', moduleName='my_template', className='other_name',
+            compilerSettings={'titleCaseClassNames': True})
+        self.assertIn('class OtherName(', pysrc)
+
+
+class ExtendsTest(CompileTest):
+
+    baseTemplate = """\
+#extends my_base
+#implements respond
+Hello
+"""
+
+    def test_off_by_default(self):
+        pysrc = self.compile(self.baseTemplate)
+        self.assertIn('from my_base import my_base', pysrc)
+        self.assertIn('class my_template(my_base)', pysrc)
+
+    def test_title_case(self):
+        pysrc = self.compile(self.baseTemplate, titleCaseClassNames=True)
+        self.assertIn('from my_base import MyBase', pysrc)
+        self.assertIn('class MyTemplate(MyBase)', pysrc)
+
+    def test_title_case_dotted(self):
+        pysrc = self.compile("""\
+#extends templates.my_base
+#implements respond
+Hello
+""", titleCaseClassNames=True)
+        self.assertIn('from templates.my_base import MyBase', pysrc)
+        self.assertIn('class MyTemplate(MyBase)', pysrc)
+
+    def test_title_case_module_named_after_its_class(self):
+        pysrc = self.compile("""\
+#extends my_base.my_base
+#implements respond
+Hello
+""", titleCaseClassNames=True)
+        self.assertIn('from my_base import MyBase', pysrc)
+        self.assertIn('class MyTemplate(MyBase)', pysrc)
+
+    def test_explicit_class_name_is_kept(self):
+        # The last chunk names a class, not a module, so it is left alone.
+        pysrc = self.compile("""\
+#extends Cheetah.Templates.SkeletonPage.SkeletonPage
+#implements respond
+Hello
+""", titleCaseClassNames=True)
+        self.assertIn(
+            'from Cheetah.Templates.SkeletonPage import SkeletonPage', pysrc)
+
+    def test_imported_class_name_is_kept(self):
+        pysrc = self.compile("""\
+#from Cheetah.Templates.SkeletonPage import SkeletonPage
+#extends SkeletonPage
+#implements respond
+Hello
+""", titleCaseClassNames=True)
+        self.assertIn('class MyTemplate(SkeletonPage)', pysrc)
+
+
+class InheritanceTest(unittest.TestCase):
+    """Compile a base and a derived template and run the derived one."""
+
+    settings = {'titleCaseClassNames': True}
+
+    moduleNames = ('inherit_base', 'inherit_template')
+
+    def setUp(self):
+        self.tmpDir = tempfile.mkdtemp()
+        sys.path.insert(0, self.tmpDir)
+        self.dropModules()
+
+    def tearDown(self):
+        sys.path.remove(self.tmpDir)
+        self.dropModules()
+        shutil.rmtree(self.tmpDir, ignore_errors=True)
+
+    def dropModules(self):
+        for moduleName in self.moduleNames:
+            sys.modules.pop(moduleName, None)
+
+    def writeTemplate(self, moduleName, source):
+        pysrc = compileToSource(
+            source, moduleName=moduleName, className=moduleName,
+            compilerSettings=self.settings)
+        pyFile = open(os.path.join(self.tmpDir, moduleName + '.py'), 'w')
+        try:
+            pyFile.write(pysrc)
+        finally:
+            pyFile.close()
+
+    def test_inheritance(self):
+        self.writeTemplate('inherit_base', """\
+#def greet
+Hello from the base
+#end def
+""")
+        self.writeTemplate('inherit_template', """\
+#extends inherit_base
+#implements respond
+$greet()""")
+        from inherit_template import InheritTemplate
+        self.assertEqual(str(InheritTemplate()), 'Hello from the base\n')
+
+
+class KeywordClassNameTest(unittest.TestCase):
+
+    def test_compiles_and_runs(self):
+        klass = Template.compile(
+            'Hello', moduleName='none',
+            compilerSettings={'titleCaseClassNames': True})
+        self.assertEqual(klass.__name__, 'None_')
+        self.assertEqual(str(klass()), 'Hello')
+
+
+class CustomCompilerClassTest(unittest.TestCase):
+    """A compilerClass of one's own need not know about the setting"""
+
+    class PlainCompiler(object):
+        def __init__(self, *args, **kw):
+            self._compiler = ModuleCompiler(*args, **kw)
+
+        def compile(self):
+            return self._compiler.compile()
+
+        def getModuleCode(self):
+            return self._compiler.getModuleCode()
+
+        def getModuleEncoding(self):
+            return self._compiler.getModuleEncoding()
+
+    def test_compiles(self):
+        klass = Template.compile('Hello', moduleName='plain_template',
+                                 compilerClass=self.PlainCompiler)
+        self.assertEqual(klass.__name__, 'plain_template')
+        self.assertEqual(str(klass()), 'Hello')
+
+
+class LoadTemplateClassTest(unittest.TestCase):
+
+    moduleName = 'loaded_template'
+
+    def setUp(self):
+        self.tmpDir = tempfile.mkdtemp()
+        sys.modules.pop(self.moduleName, None)
+
+    def tearDown(self):
+        sys.modules.pop(self.moduleName, None)
+        shutil.rmtree(self.tmpDir, ignore_errors=True)
+
+    def test_loads_a_title_cased_class(self):
+        pysrc = compileToSource(
+            'Hello', moduleName=self.moduleName, className=self.moduleName,
+            compilerSettings={'titleCaseClassNames': True})
+        pyFile = open(
+            os.path.join(self.tmpDir, self.moduleName + '.py'), 'w')
+        try:
+            pyFile.write(pysrc)
+        finally:
+            pyFile.close()
+        klass = loadTemplateClass(
+            os.path.join(self.tmpDir, self.moduleName))
+        self.assertEqual(klass.__name__, 'LoadedTemplate')
+        self.assertEqual(str(klass()), 'Hello')
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/Cheetah/Tests/Test.py
+++ b/Cheetah/Tests/Test.py
@@ -35,6 +35,7 @@ import unittest  # noqa: E402 module level import not at top of file
 
 from Cheetah.Tests import Analyzer  # noqa: E402
 from Cheetah.Tests import CheetahWrapper  # noqa: E402
+from Cheetah.Tests import ClassNames  # noqa: E402
 from Cheetah.Tests import Filters  # noqa: E402
 from Cheetah.Tests import ImportHooks  # noqa: E402
 from Cheetah.Tests import LoadTemplate  # noqa: E402
@@ -51,6 +52,7 @@ SyntaxAndOutput.install_eols()
 
 suites = [
     unittest.defaultTestLoader.loadTestsFromModule(Analyzer),
+    unittest.defaultTestLoader.loadTestsFromModule(ClassNames),
     unittest.defaultTestLoader.loadTestsFromModule(Filters),
     unittest.defaultTestLoader.loadTestsFromModule(ImportHooks),
     unittest.defaultTestLoader.loadTestsFromModule(LoadTemplate),

--- a/docs/news.rst
+++ b/docs/news.rst
@@ -4,6 +4,11 @@ News
 Development (master)
 --------------------
 
+  - Added compiler setting ``titleCaseClassNames``: derive the class
+    name of a compiled template from its module name in title case,
+    so ``my_template.tmpl`` defines the class ``MyTemplate``. The
+    implicit import of ``#extends`` follows the setting.
+
   - Dropped support for Python 3.4 and 3.5.
 
 3.4.0.post5 (2025-11-29)

--- a/docs/users_guide/inheritanceEtc.rst
+++ b/docs/users_guide/inheritanceEtc.rst
@@ -67,6 +67,41 @@ practical way to get a parent template into a module is to
 precompile it, all parent templates essentially have to be
 precompiled.
 
+The class name of a precompiled template is its module name, so
+``my_template.tmpl`` defines the class ``my_template``. Turn on the
+compiler setting ``titleCaseClassNames`` to get class names in title
+case instead:
+
+::
+
+    $ cheetah compile --settings=titleCaseClassNames=True my_template.tmpl
+
+``my_template.tmpl`` now defines the class ``MyTemplate``, which you
+import as
+
+::
+
+    from my_template import MyTemplate
+
+The setting changes the implicit import of {#extends} accordingly:
+``#extends my_base`` now does ``#from my_base import MyBase``. The name
+in the {#extends} directive is still the module name; only the class
+name is converted. A name that is already in title case comes through
+unchanged, as in {#extends Cheetah.Templates.SkeletonPage.SkeletonPage},
+and a class you imported yourself is not touched at all.
+
+The conversion applies to a class name you pass to the compiler
+yourself, not only to one taken from the module name. A name that would
+collide with a Python keyword gets a trailing underscore, so
+``none.tmpl`` defines ``None_``.
+
+The class name is fixed before parsing starts, so a
+{#compiler-settings} directive inside a template comes too late and
+does not change it. Pass the setting to the compiler instead, as
+{--settings} on the command line, as {compilerSettings} to
+{Template.compile}, or as {_CHEETAH_compilerSettings} on your
+{Template} subclass.
+
 There can be only one {#extends} directive in a template and it may
 list only one class. In other words, templates don't do multiple
 inheritance. This is intentional: it's too hard to initialize


### PR DESCRIPTION
Closes #67.

With the setting on, `my_template.tmpl` compiles to `class MyTemplate`, and `#extends my_base` does `from my_base import MyBase`. The name in `#extends` stays the module name. A name that is already in title case comes through unchanged, so `Cheetah.Templates.SkeletonPage.SkeletonPage` still imports `SkeletonPage`, and a class imported explicitly is not touched.

`Template.compile()` and `loadTemplateClass()` ask the compiler for the class name it used instead of assuming it equals the module name. A `compilerClass` of one's own does not have to implement the new method.

The setting is read once, before parsing, so a `#compiler-settings` directive does not reach it. Reading it live would rename the base class in the `#extends` import but not the class of the template itself. `--settings`, `compilerSettings=` and `_CHEETAH_compilerSettings` all work, and the docs say so.

Default is off.

21 new tests in `Cheetah/Tests/ClassNames.py`, among them one that compiles a base and a derived template and renders it, and one for `loadTemplateClass`. Full suite passes on 2.7, 3.6 and 3.12, flake8 clean, docs build clean.