### PR TITLE
Fix three crashes in the parser

### DIFF
--- a/Cheetah/Parser.py
+++ b/Cheetah/Parser.py
@@ -1272,13 +1272,14 @@ class _LowLevelParser(SourceReader):
         """
         if token == 'c' and not self.atEnd() and self.peek() in '\'"':
             nextToken = self.getPyToken()
-            token = nextToken.upper()
-            theStr = eval(token)
+            theStr = eval(nextToken)
             endPos = self.pos()
             if not theStr:
-                return
+                # An empty string is already a valid expression.
+                return nextToken
 
-            if token.startswith(single3) or token.startswith(double3):
+            if (nextToken.startswith(single3)
+                    or nextToken.startswith(double3)):
                 startPosIdx = 3
             else:
                 startPosIdx = 1
@@ -2153,18 +2154,19 @@ class _HighLevelParser(_LowLevelParser):
         isNestedDef = (self.setting('allowNestedDefScopes')
                        and [name for name in self._openDirectivesStack
                             if name == 'def'])
-        if directiveName == 'block' or (
-                directiveName == 'def' and not isNestedDef):
-            self._compiler.startMethodDef(methodName, argsList, parserComment)
-        else:  # closure
+        isClosure = not (directiveName == 'block' or (
+            directiveName == 'def' and not isNestedDef))
+        if isClosure:
             # @@TR: temporary hack of useSearchList
             useSearchList_orig = self.setting('useSearchList')
             self.setSetting('useSearchList', False)
             self._compiler.addClosure(methodName, argsList, parserComment)
+        else:
+            self._compiler.startMethodDef(methodName, argsList, parserComment)
 
         self.getWhiteSpace(max=1)
         self.parse(breakPoint=endPos)
-        if directiveName == 'closure' or isNestedDef:
+        if isClosure:
             # @@TR: temporary hack of useSearchList
             self.setSetting('useSearchList', useSearchList_orig)
 

--- a/Cheetah/Tests/SyntaxAndOutput.py
+++ b/Cheetah/Tests/SyntaxAndOutput.py
@@ -726,6 +726,15 @@ class PlaceholderStrings(OutputTest):
 
                     "BLARG1")
 
+    def test8(self):
+        """a c'...' string containing a backslash escape"""
+        self.verify("$str(c'a\\nb')", "a\\nb")
+
+    def test9(self):
+        """an empty c'...' string"""
+        self.verify("$str(c'')", "")
+        self.verify('$str(c"")', "")
+
 
 class UnicodeStrings(OutputTest):
     def test1(self):
@@ -1925,6 +1934,11 @@ class BlockDirective(OutputTest):
         """#block without argstring, gobble WS"""
         self.verify("  #block testBlock   \n1234\n  #end block  ",
                     "1234\n")
+
+    def test2a(self):
+        """single line #block nested in a #def"""
+        self.verify("#def outer\n#block inner: hi\n#end def\n$outer()",
+                    "hi")
 
     def test3(self):
         """#block with argstring, gobble WS

--- a/docs/news.rst
+++ b/docs/news.rst
@@ -4,6 +4,16 @@ News
 Development (master)
 --------------------
 
+Bug fixes:
+
+  - Fixed ``Parser.transformToken``: it uppercased the whole string
+    literal before evaluating it, which broke every ``c'...'`` string
+    containing a backslash escape, and it returned ``None`` for an
+    empty string, which crashed the caller.
+
+  - Fixed ``Parser._eatSingleLineDef``: a single-line ``#block`` nested
+    in a ``#def`` raised ``UnboundLocalError``.
+
   - Dropped support for Python 3.4 and 3.5.
 
 3.4.0.post5 (2025-11-29)


### PR DESCRIPTION
Three templates that abort compilation on master:

```
#set $x = c'a\nb'          ParseError: malformed \N character escape
#set $x = c''              TypeError: expected string or bytes-like object, got 'NoneType'
#def outer                 UnboundLocalError: 'useSearchList_orig'
#block inner: hi
#end def
```

The first two come from `transformToken`: it uppercases the whole string literal before `eval`, and it returns `None` when the string is empty. The uppercased value is only tested for emptiness, so the call has no purpose.

The third is `_eatSingleLineDef` binding `useSearchList_orig` in one branch and reading it under a different condition.

Escapes inside `c'...'` stay uninterpreted, since the string is read character by character from the source. This only stops the crash.

Three regression tests in `SyntaxAndOutput.py`. Full suite passes on 2.7, 3.6 and 3.12, flake8 clean.