### PR TITLE
Report two compiler errors instead of crashing

### DIFF
--- a/Cheetah/Compiler.py
+++ b/Cheetah/Compiler.py
@@ -23,7 +23,7 @@ from .Version import Version, VersionTuple
 from .SettingsManager import SettingsManager
 from .Utils.Indenter import indentize  # an undocumented preprocessor
 from . import NameMapper
-from .Parser import Parser, ParseError, specialVarRE, \
+from .Parser import Parser, specialVarRE, \
     STATIC_CACHE, REFRESH_CACHE, SET_GLOBAL, SET_MODULE, \
     unicodeDirectiveRE, encodingDirectiveRE, escapedNewlineRE
 from .compat import PY2, string_type, unicode
@@ -1439,11 +1439,12 @@ class ClassCompiler(GenUtils):
         # First test to make sure that the user hasn't used
         # any fancy Cheetah syntax (placeholders, directives, etc.)
         # inside the expression
-        if attribExpr.find('VFN(') != -1 or attribExpr.find('VFFSL(') != -1:
-            raise ParseError(
-                self,
+        if (attribExpr.find('VFN(') != -1
+                or attribExpr.find('VFFSL(') != -1
+                or attribExpr.find('VFSL(') != -1):
+            raise Error(
                 'Invalid #attr directive. It should only contain '
-                + 'simple Python literals.')
+                'simple Python literals.')
         # now add the attribute
         self._generatedAttribs.append(attribExpr)
 
@@ -1692,8 +1693,8 @@ class ModuleCompiler(SettingsManager, GenUtils):
             encodingMatch = encodingDirectiveRE.search(source)
             if unicodeMatch:
                 if encodingMatch:
-                    raise ParseError(
-                        self, "#encoding and #unicode are mutually exclusive! "
+                    raise Error(
+                        "#encoding and #unicode are mutually exclusive! "
                         "Use one or the other.")
                 source = unicodeDirectiveRE.sub('', source)
                 if isinstance(source, bytes):

--- a/Cheetah/Tests/SyntaxAndOutput.py
+++ b/Cheetah/Tests/SyntaxAndOutput.py
@@ -25,6 +25,7 @@ import warnings
 from Cheetah.NameMapper import NotFound
 from Cheetah.Template import Template
 from Cheetah.Parser import ParseError
+from Cheetah.Compiler import Error as CompilerError
 from Cheetah.Compiler import DEFAULT_COMPILER_SETTINGS
 from Cheetah.compat import PY2
 
@@ -785,6 +786,11 @@ class EncodingDirective(OutputTest):
 
 
 class UnicodeDirective(OutputTest):
+    def test_conflict_with_encoding(self):
+        """#unicode and #encoding together are reported, not a crash"""
+        self.assertRaises(CompilerError, Template.compile,
+                          "#unicode utf-8\n#encoding utf-8\n1234")
+
     def test1(self):
         """basic #unicode """
         self.verify("#unicode utf-8\n1234",
@@ -1738,6 +1744,11 @@ class AttrDirective(OutputTest):
         Shouldn't gobble"""
         self.verify("  --   #attr $test = 'blarg'   \n$test",
                     "  --   \nblarg")
+
+    def test6(self):
+        """#attr with a placeholder is reported, not a crash"""
+        self.assertRaises(CompilerError, Template.compile,
+                          "#attr $test = $foo\n$test")
 
 
 class DefDirective(OutputTest):

--- a/docs/news.rst
+++ b/docs/news.rst
@@ -4,6 +4,18 @@ News
 Development (master)
 --------------------
 
+Bug fixes:
+
+  - Fixed two error paths in ``Compiler`` that passed a compiler where
+    ``ParseError`` expects a stream. ``#unicode`` together with
+    ``#encoding`` raised ``RecursionError`` and an ``#attr`` directive
+    holding a placeholder raised ``AttributeError``, both instead of
+    the intended message.
+
+  - Fixed the ``#attr`` check: it looked for ``VFN(`` and ``VFFSL(``
+    but not for ``VFSL(``, the form generated when ``useStackFrames``
+    is off.
+
   - Dropped support for Python 3.4 and 3.5.
 
 3.4.0.post5 (2025-11-29)


### PR DESCRIPTION
Both sites do `raise ParseError(self, ...)`, but `ParseError.__init__` expects a stream and calls `stream.pos()` on it.

```
#unicode utf-8            RecursionError: maximum recursion depth exceeded
#encoding utf-8

#attr $test = $foo        AttributeError: pos
```

The first happens in `ModuleCompiler.__init__` before `_setupCompilerState()`, so `__getattr__` recurses on the missing `_activeClassesList`. Neither site has a stream to point at, so both raise `Error` with the message they were meant to carry.

While testing this: the `#attr` check looks for `VFN(` and `VFFSL(` but not `VFSL(`, the form generated when `useStackFrames` is off. Without the C version of NameMapper the directive it rejects went through unnoticed, so that check is in this PR too.

Two regression tests. Full suite passes on 2.7, 3.6 and 3.12 in both namemapper modes, flake8 clean.