### PR TITLE
Fix SourceReader.ungetc

### DIFF
--- a/Cheetah/SourceReader.py
+++ b/Cheetah/SourceReader.py
@@ -159,12 +159,13 @@ class SourceReader(object):
         return self._src[pos]
 
     def ungetc(self, c=None):
-        if not self.atStart():
+        if self.atStart():
             raise Error('Already at beginning of stream')
 
         self._pos -= 1
         if c is not None:
-            self._src[self._pos] = c
+            self._src = (self._src[:self._pos] + c
+                         + self._src[self._pos + 1:])
 
     def advance(self, offset=1):
         self.checkPos(self._pos + offset)

--- a/Cheetah/Tests/Misc.py
+++ b/Cheetah/Tests/Misc.py
@@ -1,6 +1,7 @@
 import unittest
 
 from Cheetah import SettingsManager
+from Cheetah.SourceReader import Error, SourceReader
 
 
 class SettingsManagerTests(unittest.TestCase):
@@ -12,3 +13,22 @@ class SettingsManagerTests(unittest.TestCase):
         }
         result = SettingsManager.mergeNestedDictionaries(left, right)
         self.assertEqual(result, expect)
+
+
+class SourceReaderTests(unittest.TestCase):
+    def test_ungetc(self):
+        reader = SourceReader('abc')
+        self.assertEqual(reader.getc(), 'a')
+        reader.ungetc()
+        self.assertEqual(reader.getc(), 'a')
+
+    def test_ungetc_replaces_the_character(self):
+        reader = SourceReader('abc')
+        reader.getc()
+        reader.ungetc('x')
+        self.assertEqual(reader.getc(), 'x')
+        self.assertEqual(reader.getc(), 'b')
+
+    def test_ungetc_at_the_start(self):
+        reader = SourceReader('abc')
+        self.assertRaises(Error, reader.ungetc)

--- a/docs/news.rst
+++ b/docs/news.rst
@@ -4,6 +4,12 @@ News
 Development (master)
 --------------------
 
+Bug fixes:
+
+  - Fixed ``SourceReader.ungetc``: the guard was inverted, so it raised
+    in the normal case, and writing the character back did an item
+    assignment on a string.
+
   - Dropped support for Python 3.4 and 3.5.
 
 3.4.0.post5 (2025-11-29)


### PR DESCRIPTION
`ungetc` cannot succeed under any input on master.

```
>>> r = SourceReader('abc'); r.getc(); r.ungetc()
Error: Already at beginning of stream
```

The guard is inverted, so the method raises whenever there is a character to unget. At position 0 it falls through and sets `self._pos = -1`, and the following `self._src[self._pos] = c` is an item assignment on a str.

Nothing in Cheetah calls it, so this is public API only. Three tests in `Tests/Misc.py`. Full suite passes on 2.7, 3.6 and 3.12, flake8 clean.