### PR TITLE
Fix IndexError on a blank setting value

### DIFF
--- a/Cheetah/SettingsManager.py
+++ b/Cheetah/SettingsManager.py
@@ -48,6 +48,8 @@ def stringIsNumber(S):
     This also works for complex numbers and numbers with +/- in front."""
 
     S = S.strip()
+    if not S:
+        return False
 
     if S[0] in '-+' and len(S) > 1:
         S = S[1:].strip()

--- a/Cheetah/Tests/Misc.py
+++ b/Cheetah/Tests/Misc.py
@@ -12,3 +12,15 @@ class SettingsManagerTests(unittest.TestCase):
         }
         result = SettingsManager.mergeNestedDictionaries(left, right)
         self.assertEqual(result, expect)
+
+    def test_stringIsNumber(self):
+        self.assertTrue(SettingsManager.stringIsNumber('42'))
+        self.assertTrue(SettingsManager.stringIsNumber(' -1.5 '))
+        self.assertFalse(SettingsManager.stringIsNumber('x'))
+        self.assertFalse(SettingsManager.stringIsNumber(''))
+        self.assertFalse(SettingsManager.stringIsNumber('   '))
+
+    def test_empty_setting_value(self):
+        manager = SettingsManager.SettingsManager()
+        manager.updateSettingsFromConfigStr('foo =')
+        self.assertEqual(manager.setting('foo'), '')

--- a/docs/news.rst
+++ b/docs/news.rst
@@ -4,6 +4,13 @@ News
 Development (master)
 --------------------
 
+Bug fixes:
+
+  - Fixed ``SettingsManager.stringIsNumber``: it indexed the string
+    without checking for an empty one, so a config file or a
+    ``#compiler-settings`` block with a blank value raised
+    ``IndexError``.
+
   - Dropped support for Python 3.4 and 3.5.
 
 3.4.0.post5 (2025-11-29)


### PR DESCRIPTION
```
>>> SettingsManager().updateSettingsFromConfigStr('foo =')
IndexError: string index out of range
```

`stringIsNumber` reads `S[0]` after `strip()` without checking for the empty string. Every config value goes through it, including every value in a `#compiler-settings` block. An empty string is not a number, so it now returns False and the value is kept as `''`.

Two tests in `Tests/Misc.py`. Full suite passes on 2.7, 3.6 and 3.12, flake8 clean.