### PR TITLE
Fix the cache stores and non-ASCII cache keys

### DIFF
--- a/Cheetah/CacheRegion.py
+++ b/Cheetah/CacheRegion.py
@@ -25,7 +25,23 @@ except ImportError:
     from md5 import md5
 
 import time
+
 from . import CacheStore
+from .compat import unicode
+
+
+def _hashKey(key):
+    """Hash a cache key
+
+    md5 is not used as a security primitive here, so it has to keep
+    working on a FIPS-enabled build.
+    """
+    if not isinstance(key, bytes):
+        key = unicode(key).encode('utf-8')
+    try:
+        return md5(key, usedforsecurity=False).hexdigest()
+    except TypeError:  # Python < 3.9
+        return md5(key).hexdigest()
 
 
 class CacheItem(object):
@@ -129,7 +145,7 @@ class CacheRegion(object):
 
             Returns a `CacheItem` instance.
         """
-        cacheItemID = md5(str(cacheItemID).encode('ascii')).hexdigest()
+        cacheItemID = _hashKey(cacheItemID)
 
         if cacheItemID not in self._cacheItems:
             cacheItem = self._cacheItemClass(

--- a/Cheetah/CacheStore.py
+++ b/Cheetah/CacheStore.py
@@ -52,8 +52,8 @@ class MemoryCacheStore(AbstractCacheStore):
         self._data[key] = (val, time)
 
     def replace(self, key, val, time=0):
-        if key in self._data:
-            raise Error('a value for key %r is already in the cache' % key)
+        if key not in self._data:
+            raise Error('a value for key %r is not in the cache' % key)
         self._data[key] = (val, time)
 
     def delete(self, key):
@@ -72,7 +72,7 @@ class MemoryCacheStore(AbstractCacheStore):
 
 
 class MemcachedCacheStore(AbstractCacheStore):
-    servers = ('127.0.0.1:11211')
+    servers = ('127.0.0.1:11211',)
 
     def __init__(self, servers=None, debug=False):
         if servers is None:
@@ -87,13 +87,11 @@ class MemcachedCacheStore(AbstractCacheStore):
         res = self._client.add(key, val, time)
         if not res:
             raise Error('a value for key %r is already in the cache' % key)
-        self._data[key] = (val, time)
 
     def replace(self, key, val, time=0):
         res = self._client.replace(key, val, time)
         if not res:
-            raise Error('a value for key %r is already in the cache' % key)
-        self._data[key] = (val, time)
+            raise Error('a value for key %r is not in the cache' % key)
 
     def delete(self, key):
         res = self._client.delete(key, time=0)

--- a/Cheetah/Tests/Misc.py
+++ b/Cheetah/Tests/Misc.py
@@ -1,6 +1,10 @@
+# -*- coding: utf-8 -*-
+
 import unittest
 
 from Cheetah import SettingsManager
+from Cheetah.CacheRegion import CacheRegion
+from Cheetah.CacheStore import Error as CacheError, MemoryCacheStore
 
 
 class SettingsManagerTests(unittest.TestCase):
@@ -12,3 +16,33 @@ class SettingsManagerTests(unittest.TestCase):
         }
         result = SettingsManager.mergeNestedDictionaries(left, right)
         self.assertEqual(result, expect)
+
+
+class MemoryCacheStoreTests(unittest.TestCase):
+    def test_add(self):
+        store = MemoryCacheStore()
+        store.add('k', 'v')
+        self.assertEqual(store.get('k'), 'v')
+        self.assertRaises(CacheError, store.add, 'k', 'w')
+
+    def test_replace_needs_the_key(self):
+        store = MemoryCacheStore()
+        self.assertRaises(CacheError, store.replace, 'k', 'v')
+
+    def test_replace(self):
+        store = MemoryCacheStore()
+        store.set('k', 'v')
+        store.replace('k', 'w')
+        self.assertEqual(store.get('k'), 'w')
+
+
+class CacheRegionTests(unittest.TestCase):
+    def test_non_ascii_vary_by(self):
+        region = CacheRegion('r')
+        item = region.getCacheItem(u'M\xfcnchen')
+        self.assertIs(region.getCacheItem(u'M\xfcnchen'), item)
+        self.assertIsNot(region.getCacheItem(u'Berlin'), item)
+
+    def test_key_is_stable_for_ascii(self):
+        region = CacheRegion('r')
+        self.assertIs(region.getCacheItem('x'), region.getCacheItem(u'x'))

--- a/docs/news.rst
+++ b/docs/news.rst
@@ -4,6 +4,21 @@ News
 Development (master)
 --------------------
 
+Bug fixes:
+
+  - Fixed ``MemoryCacheStore.replace``: it was a copy of ``add`` and
+    raised when the key was present instead of when it was missing.
+
+  - Fixed ``MemcachedCacheStore``: ``servers`` was a string instead of
+    a tuple, ``add`` and ``replace`` wrote to a ``_data`` attribute
+    that only exists in ``MemoryCacheStore``, and ``replace`` reported
+    the wrong condition.
+
+  - Fixed ``CacheRegion.getCacheItem``: it encoded the ``varyBy`` value
+    as ASCII, so any non-ASCII cache key raised ``UnicodeEncodeError``.
+    The key also no longer asks ``md5`` for a security primitive, which
+    it never was, so it keeps working on FIPS-enabled builds.
+
   - Dropped support for Python 3.4 and 3.5.
 
 3.4.0.post5 (2025-11-29)


### PR DESCRIPTION
Three things in the caching code.

`MemoryCacheStore.replace` is a copy of `add`. It raises when the key is present and inserts silently when it is absent, the opposite of the docstring at the top of the module.

```
>>> s = MemoryCacheStore()
>>> s.replace('k', 'v')     # empty store: inserts, should raise
>>> s.replace('k', 'w')
Error: a value for key 'k' is already in the cache
```

`MemcachedCacheStore` has a missing comma in `servers`, so `memcache.Client` gets a string and iterates it per character. `add` and `replace` write to `self._data`, which only exists in `MemoryCacheStore`, so every successful call raises `AttributeError`.

`CacheRegion.getCacheItem` encodes the `varyBy` value as ASCII:

```
>>> CacheRegion('r').getCacheItem('München')
UnicodeEncodeError: 'ascii' codec can't encode character '\xfc'
```

UTF-8 leaves the hash of every existing ASCII key untouched, so no cache is invalidated. The call also passes `usedforsecurity=False` where the interpreter takes it; a cache key is not a security primitive, and md5 is unavailable on FIPS-enabled builds.

Five tests in `Tests/Misc.py`. Full suite passes on 2.7, 3.6 and 3.12, flake8 clean.