### PR TITLE
Close the traceback cache file

### DIFF
--- a/Cheetah/Template.py
+++ b/Cheetah/Template.py
@@ -808,7 +808,8 @@ class Template(Servlet):
 
                     __file__ = os.path.join(cacheDirForModuleFiles, __file__)
                     # @@TR: might want to assert that it doesn't already exist
-                    open(__file__, 'w').write(generatedModuleCode)
+                    with open(__file__, 'w') as _py_file:
+                        _py_file.write(generatedModuleCode)
                     # @@TR: should probably restrict the perms, etc.
 
                 mod = types.ModuleType(str(uniqueModuleName))

--- a/Cheetah/Tests/Template.py
+++ b/Cheetah/Tests/Template.py
@@ -178,6 +178,29 @@ class OpenFileTest(TemplateTest):
             tmpl_file.close()
 
 
+class ModuleFileCacheTest(TemplateTest):
+    def setUp(self):
+        self.cacheDir = tempfile.mkdtemp()
+
+    def tearDown(self):
+        shutil.rmtree(self.cacheDir, ignore_errors=True)
+
+    def test_module_file_is_complete(self):
+        klass = Template.compile(
+            'Hello', cacheModuleFilesForTracebacks=True,
+            cacheDirForModuleFiles=self.cacheDir)
+        cached = os.listdir(self.cacheDir)
+        self.assertEqual(len(cached), 1)
+        moduleFile = open(os.path.join(self.cacheDir, cached[0]))
+        try:
+            source = moduleFile.read()
+        finally:
+            moduleFile.close()
+        self.assertIn('class ', source)
+        self.assertTrue(source.endswith('\n'))
+        self.assertEqual(str(klass()), 'Hello')
+
+
 class ClassMethods_subclass(TemplateTest):
 
     def test_basicUsage(self):

--- a/docs/news.rst
+++ b/docs/news.rst
@@ -4,6 +4,11 @@ News
 Development (master)
 --------------------
 
+Bug fixes:
+
+  - Fixed ``Template.compile``: the module file written for
+    ``cacheModuleFilesForTracebacks`` was never closed.
+
   - Dropped support for Python 3.4 and 3.5.
 
 3.4.0.post5 (2025-11-29)


### PR DESCRIPTION
`open(__file__, 'w').write(generatedModuleCode)` in `Template.compile` leaves the file object open. CPython closes it by refcount and emits a ResourceWarning; on PyPy the file can be left empty or truncated, which defeats the feature it implements.

The call sits in a `try` whose `finally` releases `_CHEETAH_compileLock`, so a write failure released the lock and left a partial file behind.

CPython's refcounting hides this, so the test in `Tests/Template.py` covers that the file is written completely rather than reproducing the leak. Full suite passes on 2.7, 3.6 and 3.12, flake8 clean.