### PR TITLE
Keep the NotFound message on Python 3.12+

### DIFF
--- a/Cheetah/Tests/NameMapper.py
+++ b/Cheetah/Tests/NameMapper.py
@@ -545,6 +545,29 @@ if sys.platform.startswith('java'):
     del VFF, VFFSL, VFFSL_2, VFFSL_3, VFFSL_4
 
 
+class NotFoundMessage(unittest.TestCase):
+    """The message names the missing key and the name being searched"""
+
+    def searchFor(self, name):
+        try:
+            valueForName(DummyClass(), name)
+        except NotFound as exc:
+            return str(exc)
+        self.fail('%s was found' % name)
+
+    def test_names_the_missing_key(self):
+        self.assertIn("cannot find 'missingAttr'",
+                      self.searchFor('missingAttr'))
+
+    def test_names_what_was_searched_for(self):
+        self.assertIn("while searching for 'classVar1.missingAttr'",
+                      self.searchFor('classVar1.missingAttr'))
+
+    def test_wraps_only_once(self):
+        message = self.searchFor('classVar1.missingAttr')
+        self.assertEqual(message.count('while searching'), 1)
+
+
 class MapBuiltins(unittest.TestCase):
     def test_int(self):
         from Cheetah.Template import Template

--- a/Cheetah/c/_namemapper.c
+++ b/Cheetah/c/_namemapper.c
@@ -39,10 +39,16 @@ static void setNotFoundException(char *key, PyObject *namespace)
     Py_XDECREF(exceptionStr);
 }
 
+#if PY_MAJOR_VERSION >= 3
+#define NM_ToUnicode PyObject_Str
+#else
+#define NM_ToUnicode PyObject_Unicode
+#endif
+
 static int wrapInternalNotFoundException(char *fullName, PyObject *namespace)
 {
     PyObject *excType, *excValue, *excTraceback, *isAlreadyWrapped = NULL;
-    PyObject *newExcValue = NULL;
+    PyObject *excStr = NULL, *newExcValue = NULL;
     if (!ALLOW_WRAPPING_OF_NOTFOUND_EXCEPTIONS) {
         return 0;
     }
@@ -53,17 +59,31 @@ static int wrapInternalNotFoundException(char *fullName, PyObject *namespace)
 
     if (PyErr_GivenExceptionMatches(PyErr_Occurred(), NotFound)) {
         PyErr_Fetch(&excType, &excValue, &excTraceback);
-        isAlreadyWrapped = PyObject_CallMethod(excValue, "find", "s", "while searching");
+        /* Python 3.12 keeps the exception normalized, so excValue is an
+           instance rather than the message it was set with. */
+        excStr = NM_ToUnicode(excValue);
 
-        if (isAlreadyWrapped != NULL) {
-            if (PyLong_AsLong(isAlreadyWrapped) == -1) {
-                newExcValue = PyUnicode_FromFormat("%U while searching for \'%s\'",
-                        excValue, fullName);
+        if (excStr != NULL) {
+            isAlreadyWrapped = PyObject_CallMethod(excStr, "find", "s", "while searching");
+
+            if (isAlreadyWrapped != NULL) {
+                long alreadyWrappedAt = PyLong_AsLong(isAlreadyWrapped);
+                Py_DECREF(isAlreadyWrapped);
+                if (alreadyWrappedAt == -1 && !PyErr_Occurred()) {
+                    newExcValue = PyUnicode_FromFormat("%U while searching for \'%s\'",
+                            excStr, fullName);
+                }
             }
-            Py_DECREF(isAlreadyWrapped);
+            Py_DECREF(excStr);
+        }
+        /* Anything that went wrong above only costs the added context. */
+        PyErr_Clear();
+
+        if (newExcValue == NULL) {
+            newExcValue = excValue;
         }
         else {
-           newExcValue = excValue;
+            Py_XDECREF(excValue);
         }
         PyErr_Restore(excType, newExcValue, excTraceback);
         return -1;

--- a/docs/news.rst
+++ b/docs/news.rst
@@ -4,6 +4,14 @@ News
 Development (master)
 --------------------
 
+Bug fixes:
+
+  - Fixed ``_namemapper.c``: ``NotFound`` lost the "while searching
+    for" part of its message on Python 3.12+, where the interpreter
+    keeps the exception normalized and the wrapper called ``.find`` on
+    the exception instead of on its text. The exception value was
+    leaked on every wrap, too.
+
   - Dropped support for Python 3.4 and 3.5.
 
 3.4.0.post5 (2025-11-29)


### PR DESCRIPTION
`NotFound` lost the "while searching for" part of its message. Measured with `valueForName(obj, 'v.missing')` and the C version built, on master:

```
2.7    cannot find 'missing' while searching for 'v.missing'
3.12   cannot find 'missing'
```

`wrapInternalNotFoundException` calls `.find` on what `PyErr_Fetch` returns. That used to be the message string the exception was set with, but a normalized exception is an instance and has no `.find`. The call fails, the else branch keeps the original value, and nothing is added. The pure Python NameMapper reads `exc.args[0]` and is unaffected, so the two implementations disagreed.

Two more things in the same function. When the message was already wrapped, `newExcValue` stayed `NULL` and `PyErr_Restore` discarded the message entirely. And the reference `PyErr_Fetch` hands over was never released when the value was replaced.

Three tests in `Tests/NameMapper.py`, which run against both implementations. Full suite passes with the C extension built on 2.7, 3.6 and 3.12, and in `--namemapper-pure` mode, flake8 clean.